### PR TITLE
Add basic Smart Port Logistics package example

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -108,3 +108,10 @@ Perfect for:
 
 > Save hours in port-side scheduling and eliminate hidden logistics delays with intelligent, regulation-aware automation.
 
+
+---
+
+## 📁 Sample Package
+
+A minimal `.rapp` package demonstrating the expected layout is available in `smart_port_logistics_basic.rapp/`. It contains a `meta.json`, an `app.json` and placeholder workflow, document and regulation files that reflect the capabilities listed above.
+

--- a/smart_port_logistics_basic.rapp/app.json
+++ b/smart_port_logistics_basic.rapp/app.json
@@ -1,0 +1,12 @@
+{
+  "defaultRoute": "app_dashboard_index",
+  "requiresInitialSetup": false,
+  "priority": 10,
+  "icon": "fa-anchor",
+  "color": "navy",
+  "description": "Automates port scheduling, customs checks, and last-mile logistics.",
+  "menu": {
+    "Booking": "workflows/smart-slot-booking.json",
+    "Tracking": "workflows/last-mile-delivery-tracking.json"
+  }
+}

--- a/smart_port_logistics_basic.rapp/documents/customs-clearance-form.txt
+++ b/smart_port_logistics_basic.rapp/documents/customs-clearance-form.txt
@@ -1,0 +1,1 @@
+Customs clearance form placeholder

--- a/smart_port_logistics_basic.rapp/documents/driver-entry-pass.txt
+++ b/smart_port_logistics_basic.rapp/documents/driver-entry-pass.txt
@@ -1,0 +1,1 @@
+Driver entry pass placeholder

--- a/smart_port_logistics_basic.rapp/documents/hazmat-permit-request.txt
+++ b/smart_port_logistics_basic.rapp/documents/hazmat-permit-request.txt
@@ -1,0 +1,1 @@
+Hazmat permit request placeholder

--- a/smart_port_logistics_basic.rapp/documents/port-booking-request-template.txt
+++ b/smart_port_logistics_basic.rapp/documents/port-booking-request-template.txt
@@ -1,0 +1,1 @@
+Port booking request template placeholder

--- a/smart_port_logistics_basic.rapp/meta.json
+++ b/smart_port_logistics_basic.rapp/meta.json
@@ -1,0 +1,29 @@
+{
+  "key": "smart_port_logistics",
+  "name": "Smart Port Logistics",
+  "version": "1.0.0",
+  "type": "app",
+  "entry": "app.json",
+  "workflows": [
+    "workflows/smart-slot-booking.json",
+    "workflows/shipment-rebooking.json",
+    "workflows/customs-doc-validation.json",
+    "workflows/port-delay-escalation.json",
+    "workflows/last-mile-delivery-tracking.json"
+  ],
+  "documents": [
+    "documents/port-booking-request-template.txt",
+    "documents/customs-clearance-form.txt",
+    "documents/hazmat-permit-request.txt",
+    "documents/driver-entry-pass.txt"
+  ],
+  "regulations": [
+    "regulations/customs-entry-validation.json",
+    "regulations/hazardous-materials-declaration.json",
+    "regulations/port-entry-permit-check.json",
+    "regulations/dock-scheduling-rule.json"
+  ],
+  "available": true,
+  "description": "California port workflows for imports, booking, tracking, and document checks at Los Angeles and Long Beach.",
+  "tags": ["logistics", "port", "automation"]
+}

--- a/smart_port_logistics_basic.rapp/regulations/customs-entry-validation.json
+++ b/smart_port_logistics_basic.rapp/regulations/customs-entry-validation.json
@@ -1,0 +1,3 @@
+{
+  "rule": "Validate customs entry documentation"
+}

--- a/smart_port_logistics_basic.rapp/regulations/dock-scheduling-rule.json
+++ b/smart_port_logistics_basic.rapp/regulations/dock-scheduling-rule.json
@@ -1,0 +1,3 @@
+{
+  "rule": "Ensure dock scheduling compliance"
+}

--- a/smart_port_logistics_basic.rapp/regulations/hazardous-materials-declaration.json
+++ b/smart_port_logistics_basic.rapp/regulations/hazardous-materials-declaration.json
@@ -1,0 +1,3 @@
+{
+  "rule": "Check hazardous materials declaration"
+}

--- a/smart_port_logistics_basic.rapp/regulations/port-entry-permit-check.json
+++ b/smart_port_logistics_basic.rapp/regulations/port-entry-permit-check.json
@@ -1,0 +1,3 @@
+{
+  "rule": "Verify port entry permits"
+}

--- a/smart_port_logistics_basic.rapp/workflows/customs-doc-validation.json
+++ b/smart_port_logistics_basic.rapp/workflows/customs-doc-validation.json
@@ -1,0 +1,4 @@
+{
+  "name": "customs-doc-validation",
+  "steps": []
+}

--- a/smart_port_logistics_basic.rapp/workflows/last-mile-delivery-tracking.json
+++ b/smart_port_logistics_basic.rapp/workflows/last-mile-delivery-tracking.json
@@ -1,0 +1,4 @@
+{
+  "name": "last-mile-delivery-tracking",
+  "steps": []
+}

--- a/smart_port_logistics_basic.rapp/workflows/port-delay-escalation.json
+++ b/smart_port_logistics_basic.rapp/workflows/port-delay-escalation.json
@@ -1,0 +1,4 @@
+{
+  "name": "port-delay-escalation",
+  "steps": []
+}

--- a/smart_port_logistics_basic.rapp/workflows/shipment-rebooking.json
+++ b/smart_port_logistics_basic.rapp/workflows/shipment-rebooking.json
@@ -1,0 +1,4 @@
+{
+  "name": "shipment-rebooking",
+  "steps": []
+}

--- a/smart_port_logistics_basic.rapp/workflows/smart-slot-booking.json
+++ b/smart_port_logistics_basic.rapp/workflows/smart-slot-booking.json
@@ -1,0 +1,4 @@
+{
+  "name": "smart-slot-booking",
+  "steps": []
+}


### PR DESCRIPTION
## Summary
- add `smart_port_logistics_basic.rapp` showcasing required package layout with meta and app descriptors
- document sample package in Readme

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af1935dfa8832aaa096185bb8d61bd