### PR TITLE
Add Port Authority integration and US customs regulation

### DIFF
--- a/smart_port_logistics_basic.rapp/integrations/port-authority.json
+++ b/smart_port_logistics_basic.rapp/integrations/port-authority.json
@@ -1,0 +1,37 @@
+{
+  "type": "integration",
+  "name": "Port Authority API",
+  "scope": "port",
+  "support_url": "https://support.portauthority.example.com",
+  "auth_url": "https://api.portauthority.example.com/oauth",
+  "requirements": {
+    "client_id": {
+      "label": "Client ID",
+      "required": true
+    },
+    "client_secret": {
+      "label": "Client Secret",
+      "required": true,
+      "type": "password"
+    },
+    "base_url": {
+      "label": "Base URL",
+      "required": true
+    }
+  },
+  "hooks": [
+    {
+      "name": "Submit Slot Booking",
+      "code": "submit_slot_booking",
+      "method": "POST",
+      "hook": "{{base_url}}/slots",
+      "test_url": "{{base_url}}/slots/test",
+      "mapper": "json",
+      "actions": [
+        {
+          "type": "http"
+        }
+      ]
+    }
+  ]
+}

--- a/smart_port_logistics_basic.rapp/regulations/us-customs-entry.json
+++ b/smart_port_logistics_basic.rapp/regulations/us-customs-entry.json
@@ -1,0 +1,35 @@
+{
+  "type": "regulation",
+  "regulation_id": "us-customs-entry",
+  "title": "US Customs Entry Validation",
+  "description": "Ensures import containers meet US customs entry rules before release.",
+  "jurisdiction_match": ["US"],
+  "sector_match": ["maritime", "logistics"],
+  "product_type_in": ["container"],
+  "ai_adaptive_fields": [
+    {
+      "field": "entry_number",
+      "required": true
+    },
+    {
+      "field": "importer_record",
+      "dynamic_suggestion": true,
+      "context_dependencies": ["entry_number"]
+    }
+  ],
+  "intelligent_flows": [
+    {
+      "event": "document_submitted",
+      "actions": [
+        {"type": "validate", "field": "entry_number"},
+        {"type": "notify", "role": "customs_officer"}
+      ]
+    }
+  ],
+  "recommended_tasks": [
+    {
+      "task": "Upload customs entry documentation",
+      "assignee_role": "import_coordinator"
+    }
+  ]
+}

--- a/src/integrations/port-authority.json
+++ b/src/integrations/port-authority.json
@@ -1,0 +1,37 @@
+{
+  "type": "integration",
+  "name": "Port Authority API",
+  "scope": "port",
+  "support_url": "https://support.portauthority.example.com",
+  "auth_url": "https://api.portauthority.example.com/oauth",
+  "requirements": {
+    "client_id": {
+      "label": "Client ID",
+      "required": true
+    },
+    "client_secret": {
+      "label": "Client Secret",
+      "required": true,
+      "type": "password"
+    },
+    "base_url": {
+      "label": "Base URL",
+      "required": true
+    }
+  },
+  "hooks": [
+    {
+      "name": "Submit Slot Booking",
+      "code": "submit_slot_booking",
+      "method": "POST",
+      "hook": "{{base_url}}/slots",
+      "test_url": "{{base_url}}/slots/test",
+      "mapper": "json",
+      "actions": [
+        {
+          "type": "http"
+        }
+      ]
+    }
+  ]
+}

--- a/src/regulations/us-customs-entry.json
+++ b/src/regulations/us-customs-entry.json
@@ -1,0 +1,35 @@
+{
+  "type": "regulation",
+  "regulation_id": "us-customs-entry",
+  "title": "US Customs Entry Validation",
+  "description": "Ensures import containers meet US customs entry rules before release.",
+  "jurisdiction_match": ["US"],
+  "sector_match": ["maritime", "logistics"],
+  "product_type_in": ["container"],
+  "ai_adaptive_fields": [
+    {
+      "field": "entry_number",
+      "required": true
+    },
+    {
+      "field": "importer_record",
+      "dynamic_suggestion": true,
+      "context_dependencies": ["entry_number"]
+    }
+  ],
+  "intelligent_flows": [
+    {
+      "event": "document_submitted",
+      "actions": [
+        {"type": "validate", "field": "entry_number"},
+        {"type": "notify", "role": "customs_officer"}
+      ]
+    }
+  ],
+  "recommended_tasks": [
+    {
+      "task": "Upload customs entry documentation",
+      "assignee_role": "import_coordinator"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add Port Authority API integration definition with credential requirements and slot booking hook
- define US customs entry regulation including adaptive fields and intelligent flows

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1fb4c7120832aae891129b02a738f